### PR TITLE
Improved method naming

### DIFF
--- a/Bouncer.Test/BouncerTest/BouncerTest.cs
+++ b/Bouncer.Test/BouncerTest/BouncerTest.cs
@@ -77,7 +77,7 @@ namespace Bouncer.Test.BouncerTest
         }
 
         [TestFixture]
-        public class IsNotNullOrEmpty
+        public class IsNotNullOrEmptyOnValues
         {
             private IBouncer _bouncer;
 
@@ -534,6 +534,13 @@ namespace Bouncer.Test.BouncerTest
                 Assert.DoesNotThrow(() => _bouncer.IsNotEmpty(value));
             }
 
+            [Test]
+            [TestCaseSource(nameof(IsEmptyTestCaseData))]
+            public void IsEmpty_ThenThrowException(ICollection value)
+            {
+                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotEmpty(value));
+            }
+
             private static IEnumerable<ICollection> IsNotEmptyTestCaseData
             {
                 [UsedImplicitly]
@@ -560,11 +567,83 @@ namespace Bouncer.Test.BouncerTest
                 }
             }
 
+            private static IEnumerable<ICollection> IsEmptyTestCaseData
+            {
+                [UsedImplicitly]
+                get
+                {
+                    var testCaseList = new List<ICollection>
+                    {
+                        new List<int>(),
+                        new Dictionary<int, string>(),
+                        new SortedSet<float>(),
+                        new object[0],
+                        new Stack<int>()
+                    };
+
+                    foreach (var collection in testCaseList)
+                    {
+                        yield return collection;
+                    }
+                }
+            }
+        }
+
+        [TestFixture]
+        public class IsNotNullOrEmptyOnCollection
+        {
+            private IBouncer _bouncer;
+
+            [SetUp]
+            public void SetUp()
+            {
+                _bouncer = new BrutalHack.Bouncer.Bouncer();
+            }
+
+            [Test]
+            public void IsNull_ThenThrowException()
+            {
+                Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNullOrEmpty(null));
+            }
+
+            [Test]
+            [TestCaseSource(nameof(IsNotEmptyTestCaseData))]
+            public void IsNotEmpty_ThenDoNothing(ICollection value)
+            {
+                Assert.DoesNotThrow(() => _bouncer.IsNotNullOrEmpty(value));
+            }
+
             [Test]
             [TestCaseSource(nameof(IsEmptyTestCaseData))]
             public void IsEmpty_ThenThrowException(ICollection value)
             {
-                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotEmpty(value));
+                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrEmpty(value));
+            }
+
+            private static IEnumerable<ICollection> IsNotEmptyTestCaseData
+            {
+                [UsedImplicitly]
+                get
+                {
+                    var testCaseList = new List<ICollection>
+                    {
+                        new List<int> {1},
+                        new Dictionary<int, string>
+                        {
+                            {0, "one"},
+                            {219, "two"}
+                        },
+                        new SortedSet<float> {0f, 4f, 5f},
+                        new[] {'a', 'd'},
+                        new object[] {Guid.Empty, "hello", 4},
+                        new Stack<int>(new[] {1, 4, 6, 3, 5, 6, 2, 234, 8})
+                    };
+
+                    foreach (var collection in testCaseList)
+                    {
+                        yield return collection;
+                    }
+                }
             }
 
             private static IEnumerable<ICollection> IsEmptyTestCaseData

--- a/Bouncer.Test/BouncerTest/BouncerTest.cs
+++ b/Bouncer.Test/BouncerTest/BouncerTest.cs
@@ -33,25 +33,11 @@ namespace Bouncer.Test.BouncerTest
             [Test]
             public void OneOfManyIsNull_ThenThrowException()
             {
-                Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNull(null, "hi"));
-                try
-                {
-                    _bouncer.IsNotNull(null, "hi");
-                }
-                catch (ArgumentNullException e)
-                {
-                    StringAssert.Contains("Parameter #0", e.ParamName);
-                }
+                var parameter0Exception = Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNull(null, "hi"));
+                StringAssert.Contains("Parameter #0", parameter0Exception.ParamName);
 
-                Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNull("hi", 5, null));
-                try
-                {
-                    _bouncer.IsNotNull("hi", 5, null);
-                }
-                catch (ArgumentNullException e)
-                {
-                    StringAssert.Contains("Parameter #2", e.ParamName);
-                }
+                var parameter2Exception = Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNull("hi", 5, null));
+                StringAssert.Contains("Parameter #2", parameter2Exception.ParamName);
             }
 
             [Test]
@@ -108,25 +94,13 @@ namespace Bouncer.Test.BouncerTest
             [Test]
             public void OneOfManyIsNullOrEmpty_ThenThrowException()
             {
-                Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNullOrEmpty(null, "hi"));
-                try
-                {
-                    _bouncer.IsNotNullOrEmpty(null, "hi");
-                }
-                catch (ArgumentNullException e)
-                {
-                    StringAssert.Contains("Parameter #0", e.ParamName);
-                }
+                var parameter0Exception =
+                    Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNullOrEmpty(null, "hi"));
+                StringAssert.Contains("Parameter #0", parameter0Exception.ParamName);
 
-                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrEmpty("hi", "test", ""));
-                try
-                {
-                    _bouncer.IsNotNullOrEmpty("hi", "test", "");
-                }
-                catch (ArgumentEmptyException e)
-                {
-                    StringAssert.Contains("Parameter #2", e.ParamName);
-                }
+                var parameter2Exception =
+                    Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrEmpty("hi", "test", ""));
+                StringAssert.Contains("Parameter #2", parameter2Exception.ParamName);
             }
 
             [Test]
@@ -183,35 +157,15 @@ namespace Bouncer.Test.BouncerTest
             [Test]
             public void OneOfManyIsNullOrWhiteSpace_ThenThrowException()
             {
-                Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNullOrWhiteSpace(null, "hi"));
-                try
-                {
-                    _bouncer.IsNotNullOrWhiteSpace(null, "hi");
-                }
-                catch (ArgumentNullException e)
-                {
-                    StringAssert.Contains("Parameter #0", e.ParamName);
-                }
+                var parameter0Exception = Assert.Throws<ArgumentNullException>(() => _bouncer.IsNotNullOrWhiteSpace(null, "hi"));
 
-                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrWhiteSpace("hi", "", "test"));
-                try
-                {
-                    _bouncer.IsNotNullOrWhiteSpace("hi", "", "test");
-                }
-                catch (ArgumentEmptyException e)
-                {
-                    StringAssert.Contains("Parameter #1", e.ParamName);
-                }
+                StringAssert.Contains("Parameter #0", parameter0Exception.ParamName);
 
-                Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrWhiteSpace("hi", "test", " "));
-                try
-                {
-                    _bouncer.IsNotNullOrWhiteSpace("hi", "test", " ");
-                }
-                catch (ArgumentEmptyException e)
-                {
-                    StringAssert.Contains("Parameter #2", e.ParamName);
-                }
+                var parameter1Exception = Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrWhiteSpace("hi", "", "test"));
+                StringAssert.Contains("Parameter #1", parameter1Exception.ParamName);
+
+                var parameter2Exception = Assert.Throws<ArgumentEmptyException>(() => _bouncer.IsNotNullOrWhiteSpace("hi", "test", " "));
+                StringAssert.Contains("Parameter #2", parameter2Exception.ParamName);
             }
 
             [Test]

--- a/Bouncer/Bouncer/Bouncer.cs
+++ b/Bouncer/Bouncer/Bouncer.cs
@@ -30,10 +30,16 @@ namespace BrutalHack.Bouncer
             }
         }
 
+        [Obsolete("IsNotEmpty is deprecated, please use IsNotNullOrEmpty instead.", false)]
+        public void IsNotEmpty(ICollection collection)
+        {
+            IsNotNullOrEmpty(collection);
+        }
+
         /// <param name="collection"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentEmptyException"></exception>
-        public void IsNotEmpty(ICollection collection)
+        public void IsNotNullOrEmpty(ICollection collection)
         {
             if (collection == null)
             {

--- a/Bouncer/Bouncer/IBouncer.cs
+++ b/Bouncer/Bouncer/IBouncer.cs
@@ -10,10 +10,13 @@ namespace BrutalHack.Bouncer
         /// <exception cref="ArgumentNullException"></exception>
         void IsNotNull(params object[] values);
 
+        [Obsolete("IsNotEmpty is deprecated, please use IsNotNullOrEmpty instead.", false)]
+        void IsNotEmpty(ICollection collection);
+
         /// <param name="collection"></param>
         /// <exception cref="ArgumentNullException"></exception>
         /// <exception cref="ArgumentEmptyException"></exception>
-        void IsNotEmpty(ICollection collection);
+        void IsNotNullOrEmpty(ICollection collection);
 
         /// <param name="collection"></param>
         /// <exception cref="ArgumentNullException"></exception>


### PR DESCRIPTION
- marked IsNotEmpty as obsolete for backward compatibility
- created IsNotNullOrEmpty
- IsNotEmpty is using IsNotNullOrEmpty inside
- created additional unit tests
- avoided naming conflict in unit tests